### PR TITLE
AM-961 Fix GeoID strings for LE format

### DIFF
--- a/modules/components/widgets/antd/value/Autocomplete.jsx
+++ b/modules/components/widgets/antd/value/Autocomplete.jsx
@@ -48,9 +48,9 @@ export default (props) => {
   const minWidth = width || defaultSelectWidth;
 
   const apiSearchEndpoints = {
-    __county: "location/get-county-names-map",
-    __congress: "location/get-cd-names-map",
-    __cbsa: "location/get-cbsa-names-map"
+    _county: "location/get-county-names-map",
+    _congress: "location/get-cd-names-map",
+    _cbsa: "location/get-cbsa-names-map"
   };
 
   useEffect(() => { 


### PR DESCRIPTION
I was checking for "__county" - one to many underscores for LE. This broke the conversion from simple to complex filters.