### PR TITLE
Am 1540 react-awesome-query-builder fork updates

### DIFF
--- a/modules/components/containers/SortableContainer.jsx
+++ b/modules/components/containers/SortableContainer.jsx
@@ -73,8 +73,8 @@ const createSortableContainer = (Builder, CanMoveFn = null) =>
               startDragging.itemInfo = clone(dragging.itemInfo);
               startDragging.y = plhEl.offsetTop;
               startDragging.x = plhEl.offsetLeft;
-              startDragging.clientY += (plY - oldPlY);
-              startDragging.clientX += (plX - oldPlX);
+              if (oldPlY != null) startDragging.clientY += (plY - oldPlY);
+              if (oldPlX != null) startDragging.clientX += (plX - oldPlX);
               if (treeElContainer != document.body)
                 startDragging.scrollTop = scrollTop;
 

--- a/modules/components/widgets/antd/core/ButtonGroup.jsx
+++ b/modules/components/widgets/antd/core/ButtonGroup.jsx
@@ -2,9 +2,6 @@ import React from "react";
 import { Button } from "antd";
 const ButtonGroup = Button.Group;
 
-export default ({children, config: {settings}}) => {
-  const {renderSize} = settings;
-  return <ButtonGroup
-    size={renderSize}
-  >{children}</ButtonGroup>;
+export default ({children}) => {
+  return <ButtonGroup>{children}</ButtonGroup>;
 };

--- a/modules/components/widgets/antd/core/Conjs.jsx
+++ b/modules/components/widgets/antd/core/Conjs.jsx
@@ -41,7 +41,6 @@ export default class ConjsButtons extends PureComponent {
     return (
       <ButtonGroup
         key="group-conjs-buttons"
-        size={renderSize}
         disabled={disabled || readonly}
       >
         {showNot && (readonly ? not : true)

--- a/modules/components/widgets/antd/core/Conjs.jsx
+++ b/modules/components/widgets/antd/core/Conjs.jsx
@@ -12,11 +12,12 @@ class ConjsButton extends PureComponent {
   };
 
   render() {
-    const {disabled, item} = this.props;
+    const {disabled, item, renderSize} = this.props;
     return (
       <Button
         disabled={disabled}
         type={item.checked ? "primary" : null}
+        size={renderSize}
         onClick={this.onClick}
       >{item.label}</Button>
     );
@@ -48,6 +49,7 @@ export default class ConjsButtons extends PureComponent {
             key={"group-not"}
             onClick={this.setNot}
             type={not ? "primary" : null}
+            size={renderSize}
             disabled={readonly}
           >{notLabel}</Button>
         }
@@ -56,6 +58,7 @@ export default class ConjsButtons extends PureComponent {
             key={item.id}
             item={item}
             disabled={disabled || readonly}
+            renderSize={renderSize}
             setConjunction={setConjunction}
           />
         ))}

--- a/modules/stores/tree.js
+++ b/modules/stores/tree.js
@@ -255,7 +255,7 @@ const moveItem = (state, fromPath, toPath, placement, config) => {
     : toPath.size > 1 ? getItemByPath(state, targetPath) : null;
   const targetChildren = target ? target.get("children1") : null;
 
-  if (!source || !target)
+  if (!from || !source || !target)
     return state;
 
   const isSameParent = (source.get("id") == target.get("id"));

--- a/modules/utils/treeUtils.js
+++ b/modules/utils/treeUtils.js
@@ -33,11 +33,11 @@ export const expandTreeSubpath = (path, ...suffix) =>
 export const getItemByPath = (tree, path) => {
   let children = new Immutable.OrderedMap({ [tree.get("id")] : tree });
   let res = tree;
-  path.forEach((id) => {
-    if (!children) return;
+  for (const id of path) {
+    if (!children) { res = undefined; break; }
     res = children.get(id);
     children = res ? res.get("children1") : undefined;
-  });
+  }
   return res;
 };
 

--- a/modules/utils/treeUtils.js
+++ b/modules/utils/treeUtils.js
@@ -34,8 +34,9 @@ export const getItemByPath = (tree, path) => {
   let children = new Immutable.OrderedMap({ [tree.get("id")] : tree });
   let res = tree;
   path.forEach((id) => {
+    if (!children) return;
     res = children.get(id);
-    children = res.get("children1");
+    children = res ? res.get("children1") : undefined;
   });
   return res;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-awesome-query-builder",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "User-friendly query builder for React. Demo: https://ukrbublik.github.io/react-awesome-query-builder",
   "keywords": [
     "query-builder",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,8 @@
   },
   "devDependencies": {
     "@ant-design/icons": "^4.7.0",
+    "@date-io/core": "^1.3.6",
+    "@popperjs/core": "^2.11.5",
     "@babel/cli": "^7.14.5",
     "@babel/core": "^7.14.5",
     "@babel/plugin-proposal-class-properties": "^7.14.5",
@@ -168,7 +170,6 @@
     "eslint-plugin-babel": "^5.3.1",
     "eslint-plugin-import": "^2.23.4",
     "eslint-plugin-react": "^7.24.0",
-    "fibers": "^5.0.0",
     "file-loader": "^6.2.0",
     "karma": "^6.3.4",
     "karma-chai": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -213,7 +213,6 @@
     "react-dom": "^17.0.2",
     "react-refresh": "^0.11.0",
     "react-router-dom": "^6.2.1",
-    "react-scripts": "^5.0.1",
     "react-select": "^5.2.2",
     "reactstrap": "^9.0.0",
     "sass": "^1.35.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "sqlstring": "^2.3.2"
   },
   "peerDependencies": {
-    "@ant-design/icons": "^4.0.0",
+    "@ant-design/icons": "^4.0.0 || ^5.0.0",
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
     "@fortawesome/fontawesome-svg-core": "^1.2.36",
@@ -108,7 +108,7 @@
     "antd": "^4.0.0",
     "bootstrap": "^5.1.3",
     "material-ui-confirm": "^2.0.1 || ^3.0.0",
-    "react": "^16.8.4 || ^17.0.1",
+    "react": "^16.8.4 || ^17.0.1 || ^18.0.0",
     "react-dom": "^16.8.4 || ^17.0.1",
     "reactstrap": "^9.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -109,8 +109,27 @@
     "bootstrap": "^5.1.3",
     "material-ui-confirm": "^2.0.1 || ^3.0.0",
     "react": "^16.8.4 || ^17.0.1 || ^18.0.0",
-    "react-dom": "^16.8.4 || ^17.0.1",
+    "react-dom": "^16.8.4 || ^17.0.1 || ^18.0.0",
     "reactstrap": "^9.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@ant-design/icons": { "optional": true },
+    "@emotion/react": { "optional": true },
+    "@emotion/styled": { "optional": true },
+    "@fortawesome/fontawesome-svg-core": { "optional": true },
+    "@fortawesome/free-solid-svg-icons": { "optional": true },
+    "@fortawesome/react-fontawesome": { "optional": true },
+    "@material-ui/core": { "optional": true },
+    "@material-ui/icons": { "optional": true },
+    "@material-ui/lab": { "optional": true },
+    "@material-ui/pickers": { "optional": true },
+    "@mui/icons-material": { "optional": true },
+    "@mui/lab": { "optional": true },
+    "@mui/material": { "optional": true },
+    "antd": { "optional": true },
+    "bootstrap": { "optional": true },
+    "material-ui-confirm": { "optional": true },
+    "reactstrap": { "optional": true }
   },
   "devDependencies": {
     "@ant-design/icons": "^4.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1242,7 +1242,7 @@
   resolved "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.4.1.tgz"
   integrity sha512-ej5oVy6lykXsvieQtqZxCOaLT+xD4+QNarq78cIYISHmZXshCvROLudpQN3lfL8G0NL7plMSSK+zlyvCaIJ4Iw==
 
-"@date-io/core@^1.3.13", "@date-io/core@1.x":
+"@date-io/core@^1.3.13", "@date-io/core@^1.3.6", "@date-io/core@1.x":
   version "1.3.13"
   resolved "https://registry.npmjs.org/@date-io/core/-/core-1.3.13.tgz"
   integrity sha512-AlEKV7TxjeK+jxWVKcCFrfYAk8spX9aCyiToFIiLPtfQbsjmRGLIhb5VZgptQcJdHtLXo7+m0DuurwFgUToQuA==
@@ -3332,11 +3332,6 @@ destroy@1.2.0:
   resolved "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
 
-detect-libc@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz"
-  integrity sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==
-
 detect-node@^2.0.4:
   version "2.1.0"
   resolved "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz"
@@ -4022,13 +4017,6 @@ fd-slicer@~1.1.0:
   integrity sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==
   dependencies:
     pend "~1.2.0"
-
-fibers@^5.0.0, "fibers@>= 3.1.0":
-  version "5.0.1"
-  resolved "https://registry.npmjs.org/fibers/-/fibers-5.0.1.tgz"
-  integrity sha512-VMC7Frt87Oo0AOJ6EcPFbi+tZmkQ4tD85aatwyWL6I9cYMJmm2e+pXUJsfGZ36U7MffXtjou2XIiWJMtHriErw==
-  dependencies:
-    detect-libc "^1.0.3"
 
 file-entry-cache@^6.0.1:
   version "6.0.1"


### PR DESCRIPTION
Removing 'fibers' and 'react-scripts' removed about 60 warnings using Node 24.0.0. The ones that are left need an upgrade to yarn v4 in order to fix.

After doing this and testing I found a couple of somewhat hard to cause runtime errors with complex filter builder, mostly when dragging and dropping filters around. Main branch locally and Dev did not have this issue that I could cause (though I know that complex filters can have the issue locally and not on the server). The crashing errors have been resolved by some actual component changes/safe-guards.

For local testing: 
Replace the line for RAQB in your package.json to this: 
`    "react-awesome-query-builder": "https://github.com/SpeedeonData/react-awesome-query-builder.git#a4dab1ad589d3894eeaa5c581c3e552e37f4795a",`

run:
`rm -rf node_modules && yarn install --force && yarn start`
